### PR TITLE
Improve homepage styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,31 +4,48 @@
   <meta charset="UTF-8">
   <title>Stanislas Hildebrandt</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <style>
     body {
-      font-family: sans-serif;
-      max-width: 700px;
-      margin: 50px auto;
+      font-family: "Inter", sans-serif;
+      background: #f5f7fa;
+      color: #222;
+      line-height: 1.8;
+      max-width: 760px;
+      margin: 40px auto;
       padding: 0 20px;
-      line-height: 1.6;
     }
-    h1 { font-size: 2em; }
+    h1 { font-size: clamp(1.7rem, 4vw, 1.8rem); }
+    h2 { border-bottom: 2px solid #eee; padding-bottom: 0.3rem; margin-top: 2.5rem; letter-spacing: 0.02em; }
     .timeline details {
+      border-left: 3px solid #0070f3;
+      padding-left: 1rem;
+      background: #fff;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+      border-radius: 4px;
       margin-bottom: 10px;
     }
     .timeline summary {
       cursor: pointer;
       font-weight: bold;
     }
+    .timeline summary:hover {
+      color: #0070f3;
+    }
     .timeline .date {
       color: #555;
       margin-right: 6px;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #0d1117; color: #e6edf3; }
+      .timeline details { background: #161b22; border-left-color: #2f81f7; }
     }
   </style>
 </head>
 <body>
   <h1>Stanislas Hildebrandt</h1>
-  <p>Welcome to my personal website.</p>
   <p>I’m a mathematician and programmer based in Tokyo, currently studying Japanese and working on projects in machine learning, computer vision, and more.</p>
 
   <h2>About Me</h2>


### PR DESCRIPTION
## Summary
- remove welcome paragraph so headline shows immediately
- modernize fonts and apply lighter styling
- refresh timeline layout and interactive hover effect
- add dark mode support

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b90aab164832ca939af3a687d672c